### PR TITLE
Add activity and idea api

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {},
   "main": "index",
   "engines": {
-    "node": ">= 0.4.0",
+    "node": "0.8.x",
     "npm": ">= 1.1.49"
   },
   "scripts": {

--- a/public/data/kapost_v1.json
+++ b/public/data/kapost_v1.json
@@ -47,18 +47,53 @@
               "Description":"Ideas filtered for a specified user. Accepts both object ids and slugs, ex. '51f05bc04aaaae4ae800000d' or 'john-6'"
             },
             {
-              "Name":"campaign_id",
+              "Name":"state",
               "Required":"N",
               "Default":"",
-              "Type":"object id",
-              "Description":"Ideas filtered for a specified campaign. Accepts both object ids and slugs, ex. '51f05bc04aaaae4ae80000d' or 'awesome-video-campaign-1'"
+              "Type":"enumerated",
+              "EnumeratedList":[
+                "drafts",
+                "proposed",
+                "approved",
+                "rejected",
+                "archived"
+              ],
+              "Description":"Filter idea by its state"
             },
             {
-              "Name":"category",
+              "Name":"creator_id",
               "Required":"N",
               "Default":"",
               "Type":"array",
-              "Description":"Filter content using the specified category name(s)"
+              "Description":"Filter ideas by creator (user) ids. Accepts both object ids and slugs, ex. '51f05bc04aaaae4ae800000d' or 'samantha-james-2'"
+            },
+            {
+              "Name":"campaign_ids",
+              "Required":"N",
+              "Default":"",
+              "Type":"array",
+              "Description":"Filter ideas for specified campaigns. Accepts both object ids and slugs, ex. '51f05bc04aaaae4ae80000d' or 'awesome-video-campaign-1'"
+            },
+            {
+              "Name":"persona_ids",
+              "Required":"N",
+              "Default":"",
+              "Type":"array",
+              "Description":"If using personas and buying stages, filter by personas object ids targeted by this idea."
+            },
+            {
+              "Name":"stage_ids",
+              "Required":"N",
+              "Default":"",
+              "Type":"array",
+              "Description":"If using personas and buying stages, filter by buying stage ids targeted by this idea."
+            },
+            {
+              "Name":"categories",
+              "Required":"N",
+              "Default":"",
+              "Type":"array",
+              "Description":"Filter ideas using the specified category name(s)"
             },
             {
               "Name":"include_empty_categories",
@@ -71,45 +106,18 @@
               "Description":"Relevant only if filtering by category"
             },
             {
-              "Name":"creator_id",
-              "Required":"N",
-              "Default":"",
-              "Type":"array",
-              "Description":"Filter ideas by creator (user) ids. Accepts both object ids and slugs, ex. '51f05bc04aaaae4ae800000d' or 'samantha-james-2'"
-            },
-            {
-              "Name":"content_type_id",
-              "Required":"N",
-              "Default":"",
-              "Type":"object id",
-              "Description":"Filter content by content type id. Accepts an object id only."
-            },
-            {
               "Name":"search",
               "Required":"N",
               "Default":"",
               "Type":"string",
-              "Description":"Filter content by search phrase"
-            },
-            {
-              "Name":"state",
-              "Required":"N",
-              "Default":"",
-              "Type":"enumerated",
-              "EnumeratedList":[
-                "draft",
-                "proposed",
-                "approved",
-                "rejected",
-                "archived"
-              ],
-              "Description":"Filter idea by its state"
+              "Description":"Filter ideas by search phrase"
             }
           ]
         },
+
         {
           "MethodName": "Show Idea",
-          "Synopsis": "Retrieve a idea resource",
+          "Synopsis": "Retrieve an idea resource",
           "HTTPMethod": "GET",
           "URI": "/ideas/:id",
           "RequiresOAuth": "N",
@@ -141,7 +149,7 @@
 
         {
           "MethodName": "Create Idea",
-          "Synopsis": "Create a idea resource",
+          "Synopsis": "Create an idea resource",
           "HTTPMethod": "POST",
           "URI": "/ideas",
           "RequiresOAuth": "N",
@@ -179,11 +187,74 @@
               "Description":"Array of campaign object ids or slugs associated with this idea"
             },
             {
+              "Name":"persona_ids",
+              "Required":"N",
+              "Default":"",
+              "Type":"array",
+              "Description":"If using personas and buying stages, an array of object id's of personas targeted by this idea."
+            },
+            {
+              "Name":"stage_ids",
+              "Required":"N",
+              "Default":"",
+              "Type":"array",
+              "Description":"If using personas and buying stages, an array of object id's of buying stages targeted by this idea."
+            },
+            {
               "Name":"tags",
               "Required":"N",
               "Default":"",
               "Type":"string",
               "Description":"A string containing a comma-separated list of tags"
+            }
+          ]
+        },
+
+        {
+          "MethodName": "Update Idea",
+          "Synopsis": "Create an idea resource",
+          "HTTPMethod": "PUT",
+          "URI": "/ideas/:id",
+          "RequiresOAuth": "N",
+          "parameters":[
+            {
+              "Name":"id",
+              "Required":"Y",
+              "Default":"",
+              "Type":"string",
+              "Description":"Idea id or slug, ex 'welcome-to-kapost' or '51f05bc04aaaae4ae800000d'"
+            },
+            {
+              "Name":"title",
+              "Required":"N",
+              "Default":"",
+              "Type":"string",
+              "Description":"Title"
+            },
+            {
+              "Name":"body",
+              "Required":"N",
+              "Default":"",
+              "Type":"string",
+              "Description":"Content of idea (HTML OK)"
+            },
+            {
+              "Name":"is_draft",
+              "Required":"N",
+              "Default":"",
+              "Type":"enumerated",
+              "EnumeratedList":[
+                "true",
+                "false"
+              ],
+              "Description":"Whether or not this idea is in draft state"
+            },
+            {
+              "Name":"campaign_ids",
+              "Required":"N",
+              "Default":"",
+              "Type":"array",
+              "Description":"Array of campaign object ids or slugs associated with this idea"
             },
             {
               "Name":"persona_ids",
@@ -200,11 +271,28 @@
               "Description":"If using personas and buying stages, an array of object id's of buying stages targeted by this idea."
             },
             {
-              "Name":"content_type_id",
+              "Name":"tags",
               "Required":"N",
               "Default":"",
-              "Type":"object id",
-              "Description":"Change the content type"
+              "Type":"string",
+              "Description":"A string containing a comma-separated list of tags"
+            }
+          ]
+        },
+
+        {
+          "MethodName": "Delete Idea",
+          "Synopsis": "Destroys an idea",
+          "HTTPMethod": "DELETE",
+          "URI": "/ideas/:id",
+          "RequiresOAuth": "N",
+          "parameters":[
+            {
+              "Name":"id",
+              "Required":"Y",
+              "Default":"",
+              "Type":"object_id",
+              "Description":"The idea id to delete"
             }
           ]
         }

--- a/public/data/kapost_v1.json
+++ b/public/data/kapost_v1.json
@@ -40,13 +40,6 @@
               "Description":"The number of entries to retrieve per page."
             },
             {
-              "Name":"user_id",
-              "Required":"N",
-              "Default":"",
-              "Type":"object id",
-              "Description":"Ideas filtered for a specified user. Accepts both object ids and slugs, ex. '51f05bc04aaaae4ae800000d' or 'john-6'"
-            },
-            {
               "Name":"state",
               "Required":"N",
               "Default":"",
@@ -94,16 +87,6 @@
               "Default":"",
               "Type":"array",
               "Description":"Filter ideas using the specified category name(s)"
-            },
-            {
-              "Name":"include_empty_categories",
-              "Required":"N",
-              "Default":"",
-              "Type":"enumerated",
-              "EnumeratedList":[
-                "true"
-              ],
-              "Description":"Relevant only if filtering by category"
             },
             {
               "Name":"search",
@@ -237,6 +220,20 @@
               "Default":"",
               "Type":"string",
               "Description":"Content of idea (HTML OK)"
+            },
+            {
+              "Name":"operation",
+              "Required":"N",
+              "Default":"",
+              "Type":"enumerated",
+              "EnumeratedList":[
+                "reject",
+                "submit",
+                "approve",
+                "archive",
+                "unarchive"
+              ],
+              "Description":"Perform action to change idea state"
             },
             {
               "Name":"is_draft",

--- a/public/data/kapost_v1.json
+++ b/public/data/kapost_v1.json
@@ -1367,6 +1367,75 @@
       ]
     },
     {
+      "name":"Activity (Comments) <pre>/api/v1/ideas/:idea_id/comments/</pre> or <pre>/api/v1/content/:content_id/comments/</pre> or <pre>/api/v1/campaign/:campaign_id/comments/</pre>",
+      "methods":[
+        {
+          "MethodName": "List Comments",
+          "Synopsis": "Retrieves the activity feed for the specified idea, content, or campaign.",
+          "HTTPMethod": "GET",
+          "URI": "/content/:content_id/comments",
+          "RequiresOAuth": "N",
+          "parameters":[
+            {
+              "Name":"content_id",
+              "Required":"Y",
+              "Default":"",
+              "Type":"object id",
+              "Description":"The content id or slug, ex 'welcome-to-kapost' or '51f05bc04aaaae4ae800000d'"
+            }
+          ]
+        },
+
+        {
+          "MethodName": "Create Comment",
+          "Synopsis": "Creates a comment on the specified idea, content, or campaign.",
+          "HTTPMethod": "POST",
+          "URI": "/content/:content_id/comments",
+          "RequiresOAuth": "N",
+          "parameters":[
+            {
+              "Name":"content_id",
+              "Required":"Y",
+              "Default":"",
+              "Type":"object id",
+              "Description":"The content id or slug, ex 'welcome-to-kapost' or '51f05bc04aaaae4ae800000d'"
+            },
+            {
+              "Name":"body",
+              "Required":"N",
+              "Default":"",
+              "Type":"string",
+              "Description":"The body of the comment"
+            }
+          ]
+        },
+
+        {
+          "MethodName": "Delete Comment",
+          "Synopsis": "Destroys a comment on the specified idea, content, or campaign.",
+          "HTTPMethod": "DELETE",
+          "URI": "/content/:content_id/comments/:id",
+          "RequiresOAuth": "N",
+          "parameters":[
+            {
+              "Name":"content_id",
+              "Required":"Y",
+              "Default":"",
+              "Type":"string",
+              "Description":"The idea/content/campaign id or slug, ex 'welcome-to-kapost' or '51f05bc04aaaae4ae800000d'"
+            },
+            {
+              "Name":"id",
+              "Required":"Y",
+              "Default":"",
+              "Type":"string",
+              "Description":"The id of the comment to delete"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name":"Content Visibility<pre>/api/v1/content/:content_id/visibility</pre>",
       "methods":[
         {

--- a/public/data/kapost_v1.json
+++ b/public/data/kapost_v1.json
@@ -1,6 +1,217 @@
 {
   "endpoints":[
     {
+      "name":"Ideas <pre>/api/v1/ideas/</pre>",
+      "methods":[
+        {
+          "MethodName": "List Ideas",
+          "Synopsis": "Retrieve a filtered, paged list of idea resources",
+          "HTTPMethod": "GET",
+          "URI": "/ideas",
+          "RequiresOAuth": "N",
+          "parameters":[
+            {
+              "Name":"detail",
+              "Required":"N",
+              "Default":"basic",
+              "Type":"enumerated",
+              "EnumeratedList":[
+                "basic",
+                "full"
+              ],
+              "EnumeratedDescription":{
+                "basic": "A short, summary response",
+                "full": "All idea details are returned"
+              },
+              "Description":"The level of detail in the response for each record"
+            },
+            {
+              "Name":"page",
+              "Required":"N",
+              "Default":"1",
+              "Type":"integer",
+              "Description":"The (1-indexed) page number to retrieve."
+            },
+            {
+              "Name":"per_page",
+              "Required":"N",
+              "Default":"25",
+              "Type":"integer",
+              "Description":"The number of entries to retrieve per page."
+            },
+            {
+              "Name":"user_id",
+              "Required":"N",
+              "Default":"",
+              "Type":"object id",
+              "Description":"Ideas filtered for a specified user. Accepts both object ids and slugs, ex. '51f05bc04aaaae4ae800000d' or 'john-6'"
+            },
+            {
+              "Name":"campaign_id",
+              "Required":"N",
+              "Default":"",
+              "Type":"object id",
+              "Description":"Ideas filtered for a specified campaign. Accepts both object ids and slugs, ex. '51f05bc04aaaae4ae80000d' or 'awesome-video-campaign-1'"
+            },
+            {
+              "Name":"category",
+              "Required":"N",
+              "Default":"",
+              "Type":"array",
+              "Description":"Filter content using the specified category name(s)"
+            },
+            {
+              "Name":"include_empty_categories",
+              "Required":"N",
+              "Default":"",
+              "Type":"enumerated",
+              "EnumeratedList":[
+                "true"
+              ],
+              "Description":"Relevant only if filtering by category"
+            },
+            {
+              "Name":"creator_id",
+              "Required":"N",
+              "Default":"",
+              "Type":"array",
+              "Description":"Filter ideas by creator (user) ids. Accepts both object ids and slugs, ex. '51f05bc04aaaae4ae800000d' or 'samantha-james-2'"
+            },
+            {
+              "Name":"content_type_id",
+              "Required":"N",
+              "Default":"",
+              "Type":"object id",
+              "Description":"Filter content by content type id. Accepts an object id only."
+            },
+            {
+              "Name":"search",
+              "Required":"N",
+              "Default":"",
+              "Type":"string",
+              "Description":"Filter content by search phrase"
+            },
+            {
+              "Name":"state",
+              "Required":"N",
+              "Default":"",
+              "Type":"enumerated",
+              "EnumeratedList":[
+                "draft",
+                "proposed",
+                "approved",
+                "rejected",
+                "archived"
+              ],
+              "Description":"Filter idea by its state"
+            }
+          ]
+        },
+        {
+          "MethodName": "Show Idea",
+          "Synopsis": "Retrieve a idea resource",
+          "HTTPMethod": "GET",
+          "URI": "/ideas/:id",
+          "RequiresOAuth": "N",
+          "parameters":[
+            {
+              "Name":"id",
+              "Required":"Y",
+              "Default":"",
+              "Type":"string",
+              "Description":"Idea id or slug, ex 'welcome-to-kapost' or '51f05bc04aaaae4ae800000d'"
+            },
+            {
+              "Name":"detail",
+              "Required":"N",
+              "Default":"",
+              "Type":"enumerated",
+              "EnumeratedList":[
+                "basic",
+                "full"
+              ],
+              "EnumeratedDescription":{
+                "basic": "A short, summary response",
+                "full": "All idea details are returned"
+              },
+              "Description":"The level of detail in the response for each record"
+            }
+          ]
+        },
+
+        {
+          "MethodName": "Create Idea",
+          "Synopsis": "Create a idea resource",
+          "HTTPMethod": "POST",
+          "URI": "/ideas",
+          "RequiresOAuth": "N",
+          "parameters":[
+            {
+              "Name":"title",
+              "Required":"N",
+              "Default":"",
+              "Type":"string",
+              "Description":"Title"
+            },
+            {
+              "Name":"body",
+              "Required":"N",
+              "Default":"",
+              "Type":"string",
+              "Description":"Content of idea (HTML OK)"
+            },
+            {
+              "Name":"is_draft",
+              "Required":"N",
+              "Default":"",
+              "Type":"enumerated",
+              "EnumeratedList":[
+                "true",
+                "false"
+              ],
+              "Description":"Whether or not this idea is in draft state"
+            },
+            {
+              "Name":"campaign_ids",
+              "Required":"N",
+              "Default":"",
+              "Type":"array",
+              "Description":"Array of campaign object ids or slugs associated with this idea"
+            },
+            {
+              "Name":"tags",
+              "Required":"N",
+              "Default":"",
+              "Type":"string",
+              "Description":"A string containing a comma-separated list of tags"
+            },
+            {
+              "Name":"persona_ids",
+              "Required":"N",
+              "Default":"",
+              "Type":"array",
+              "Description":"If using personas and buying stages, an array of object id's of personas targeted by this idea."
+            },
+            {
+              "Name":"stage_ids",
+              "Required":"N",
+              "Default":"",
+              "Type":"array",
+              "Description":"If using personas and buying stages, an array of object id's of buying stages targeted by this idea."
+            },
+            {
+              "Name":"content_type_id",
+              "Required":"N",
+              "Default":"",
+              "Type":"object id",
+              "Description":"Change the content type"
+            }
+          ]
+        }
+      ]
+    },
+
+    {
       "name":"Content <pre>/api/v1/content/</pre>",
       "methods":[
         {
@@ -96,6 +307,13 @@
               "Default":"",
               "Type":"utc date",
               "Description":"Relevant only if filtering by date. Content less than or equal to this timestamp will be returned.<br/><br/><strong>Beta Warning</strong>: The format for this field will soon change to <a href='http://www.w3.org/TR/NOTE-datetime'>ISO 8601</a>."
+            },
+            {
+              "Name":"creator_id",
+              "Required":"N",
+              "Default":"",
+              "Type":"array",
+              "Description":"Filter content by creator (user) ids. Accepts both object ids and slugs, ex. '51f05bc04aaaae4ae800000d' or 'samantha-james-2'"
             },
             {
               "Name":"listener_id",

--- a/public/javascripts/docs.js
+++ b/public/javascripts/docs.js
@@ -29,6 +29,13 @@
         $(this).prev().clone().val("").insertBefore(this);
     })
 
+    $('td.parameter > input.remove-array-entry').click(function() {
+        $inputs = $(this).parent().find('.array-entry');
+        if ($inputs.length > 1) {
+            $inputs.last().remove();
+        }
+    });
+
     // Toggle all endpoints
     $('#toggle-endpoints').click(function(event) {
         event.preventDefault();

--- a/views/api.jade
+++ b/views/api.jade
@@ -130,6 +130,7 @@ block content
                                                         - else if (parameter.Type =='array')
                                                           input.array-entry(name='params[' + parameter.Name + ']', value=parameter.Default, placeholder=className, style="float: left; clear: both;")
                                                           input.add-array-entry(type='button', value='Add entry', name=parameter.Name)
+                                                          input.remove-array-entry(type='button', value='Remove entry', name=parameter.Name)
                                                         - else if (parameter.Type =='boolean')
                                                              select(name='params[' + parameter.Name + ']', placeholder=className)
                                                                   - if (parameter.Default =='')


### PR DESCRIPTION
@brandonc @ianisborn 

Adds docs for idea and comments. In conjunction with [napa PR](https://github.com/kapost/napa/pull/930) to expose a couple more routes.

Also I added a "Remove Field" button to the array fields to make testing that a little more sane.

![idea](https://cloud.githubusercontent.com/assets/1911028/7054698/72f59cfe-ddfb-11e4-92d6-f3b329bbb355.gif)
