### PR TITLE
Update node

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {},
   "main": "index",
   "engines": {
-    "node": "0.4.x",
+    "node": "0.10.x",
     "npm": ">= 1.1.49"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "main": "index",
   "engines": {
     "node": "0.10.x",
-    "npm": ">= 1.1.49"
+    "npm": ">= 3.5.x"
   },
   "scripts": {
     "start": "node_modules/.bin/supervisor -e 'js|json' app"


### PR DESCRIPTION
This app was running on `cedar-10` and heroku stopped accepting new pushes to it.

After running `heroku stack:set cedar-14 -a kapost-api-docs-staging` it could not install node `0.4`. I just bumped it up to a later release. These changes allowed the deploy to succeed.

It pushed this branch already to https://kapost-api-docs-staging.herokuapp.com/kapost_v1 to make sure it works.  I'll update prod the same way once this is merged in master.
